### PR TITLE
Fix: Oak-D parameters to use custom config file and Fixed launch file error

### DIFF
--- a/turtlebot4_bringup/launch/oakd.launch.py
+++ b/turtlebot4_bringup/launch/oakd.launch.py
@@ -31,7 +31,7 @@ def generate_launch_description():
 
     camera = LaunchConfiguration('camera')
     params_file = LaunchConfiguration('params_file')
-    namespace = ""
+    namespace = ''
 
     ARGUMENTS = [
         DeclareLaunchArgument('camera', default_value='oakd_pro'),

--- a/turtlebot4_bringup/launch/oakd.launch.py
+++ b/turtlebot4_bringup/launch/oakd.launch.py
@@ -31,7 +31,7 @@ def generate_launch_description():
 
     camera = LaunchConfiguration('camera')
     params_file = LaunchConfiguration('params_file')
-    namespace = LaunchConfiguration('namespace')
+    namespace = ""
 
     ARGUMENTS = [
         DeclareLaunchArgument('camera', default_value='oakd_pro'),


### PR DESCRIPTION
## Description

This PR addresses an issue in the `generate_launch_description` function in the `turtlebot4_bringup/launch/oakd.launch.py` launch file. Previously, the function included a `namespace` configuration that was redundant, as the namespace was already specified in the parameters file. This redundancy was causing an error as the `namespace` argument was not being passed to the `turtlebot4_bringup/launch/lite.launch.py` launch file. 

The fix involves removing the `namespace` configuration from the `generate_launch_description` function, which not only resolves the error but also simplifies the code and prevents potential conflicts between the function and parameters file.

Fixes # (please add the issue number here).
https://github.com/turtlebot/turtlebot4_robot/issues/23#issue-1931191865

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The changes were tested by running the following command:

```bash
# Run this command
ros2 launch turtlebot4_bringup oakd.launch.py
```
Now the params are taken from the custom config file resulting in changes that we make in the `oakd_lite.yaml` or `oakd_pro.yaml` file.

Please provide further instructions if necessary.
Official `depthai_ros_driver` camera launch file - [camera.launch.py](https://github.com/luxonis/depthai-ros/blob/e030c4dcdf7b471997ca80ec8b62d9dfdbb1fa90/depthai_ros_driver/launch/camera.launch.py#L99C13-L99C26) for reference.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation